### PR TITLE
Use async/await pattern instead of continuations

### DIFF
--- a/src/components/API.js
+++ b/src/components/API.js
@@ -14,34 +14,38 @@ export const API = (props) => {
   //   4. Catch errors
   React.useEffect(() => {
     // If there's no URL, or the URL is invalid, exit
-    if (state.url === '' || !isValidURL(state.url)) {
+    if (!isValidURL(state.url)) {
       return
     }
     
-    // Trigger a fetch
-    setState({ ...state, searchStatus: 'searching'})
-    fetch(`${state.url}${state.page ? `&page=${state.page}` : ''}`)
-      .then((res) => {
-        res.json().then(data => {
-          let pages
-          if (data.count > 10) {
-            pages = Math.ceil(data.count / 10)
-          }
-  
-          // Put the data into app state
-          setState({ ...state, data, pages, searchStatus: 'complete' })
-  
+    async function searchAsync()
+    {
+      setState({ ...state, searchStatus: 'searching'})
+
+      try 
+      {
+        const res = await fetch(`${state.url}${state.page ? `&page=${state.page}` : ''}`);
+        const data = await res.json();
+        
+        let pages = Math.ceil(data.count / 10)
+       
+        // Put the data into app state
+        setState((currentState) => { return { ...currentState, data, pages, searchStatus: 'complete' }})
+
           // ... and redirect
-          if (props.location.pathname === '/') {
-            props.history.push('/results')
-          }
-        })
-      })
-  
-      .catch(() => {
+        if (props.location.pathname === '/') 
+        {
+          props.history.push('/results')
+        }
+      } 
+      catch(err)
+      {
         setState({ ...state, searchStatus: 'error'})
-        throw new Error()
-      })
+        throw err
+      }
+    }
+
+    searchAsync();
   }, [state.url, state.page])
 
   return null

--- a/src/components/ResultPage.js
+++ b/src/components/ResultPage.js
@@ -9,16 +9,15 @@ export const ResultPage = (props) => {
   const url = `https://swapi.co/api${props.location.pathname}`
 
   React.useEffect(() => {
-    fetch(url)
-      .then((res) => {
-        res.json().then(data => {
-          // Put the data into app state
-          setResult({ data })
-      })
-      .catch(() => {
-        throw new Error()
-      })
-  })}, [])
+    async function fetchDataAsync()
+    {
+      let res = await fetch(url)
+      let data = await res.json()
+      setResult({data})
+    }
+
+    fetchDataAsync()
+  }, [])
   
   return (
     <>

--- a/src/components/ResultResource.js
+++ b/src/components/ResultResource.js
@@ -5,16 +5,15 @@ export const ResultResource = (props) => {
   const [data, setData] = React.useState()
 
   React.useEffect(() => {
-    fetch(props.url)
-      .then((res) => {
-        res.json().then(data => {
-          // Put the data into app state
-          setData(data)
-      })
-      .catch((err) => {
-        throw new Error()
-      })
-  })}, [])
+    async function fetchData()
+    {
+      let res = await fetch(props.url);
+      let data = await res.json();
+      setData(data);
+    }
+
+    fetchData();
+  }, [])
   
   return (
     <>

--- a/src/components/ResultsPage.js
+++ b/src/components/ResultsPage.js
@@ -3,7 +3,6 @@ import { initialState } from '../initialState'
 import { Route } from 'react-router'
 import { Context } from '../contexts'
 import { Results } from './Results'
-import { ResultPage } from './ResultPage'
 import { Pagination } from './Pagination'
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 


### PR DESCRIPTION
Replace the .then / .catch delegates with a local async function inside the respective ``useEffect``. 

The code looks more readable to me, since it's closer to the async/await pattern I recognize from C# and C++17. Comments on whether this looks like idiomatic JS are most welcome :-)

Minor additional changes:
- ``isValidURL`` is already false for empty / undefined input values
- Simpler code to initialize ``pages``
- Removing redundant import on ResultsPage.js 